### PR TITLE
쪽지 페이지 & 글 상세페이지 변경

### DIFF
--- a/src/css/post-detail.css
+++ b/src/css/post-detail.css
@@ -26,10 +26,20 @@
     font-weight: bold;
 }
 
-#post-detail .button {
+
+#post-detail .updatebtn {
     transition-duration: 0.2s;
     border: 2px solid #e7e7e7;
     padding: 10px 10px 10px 10px;
+    margin: 4% 0% 0% 0%;
+    float: right;
+}
+
+#post-detail .deletebtn {
+    transition-duration: 0.2s;
+    border: 2px solid #e7e7e7;
+    padding: 10px 10px 10px 10px;
+    margin: 4% 6% 0% 0%;
     float: right;
 }
 
@@ -44,6 +54,14 @@
     color:#ffffff;
     font-weight: bold;
     border: solid #ffffff;
+}
+
+#post-detail .postbtn {
+    margin-left: 2%;
+    padding : 1% 1% 1% 1%;
+    display: flex;
+    float:left;
+    font-size: 12px;
 }
 
 #post-detail .none {

--- a/src/hbs/message.hbs
+++ b/src/hbs/message.hbs
@@ -1,7 +1,7 @@
 <div id="message" class="page">
     <div class="container is-max-desktop">
     {{!-- 쪽지쓰기 버튼 --}}
-        <button id="createMessageButton" onclick="openCreateMessageModal()" class="button createMessageButton is-warning is-light is-rounded is-inline-block">쪽지쓰기</button>
+        <button id="createMessageButton" onclick="openCreateMessageModal()" class="button createMessageButton is-warning is-light is-rounded is-inline-block">쪽지보내기</button>
     {{!-- 쪽지 리스트 --}}
         <section id="message-list" class="section"></section>
         </div>

--- a/src/hbs/post.hbs
+++ b/src/hbs/post.hbs
@@ -1,11 +1,12 @@
 <div id="post-detail" class="page">
     <div class="container is-max-desktop">
-        <div class="post-boundary">
             <button id="deletebtn" class="button has-text-centered is-rounded deletebtn" onclick="deletePost()">삭제</button>
             <button id="updatebtn" class="button has-text-centered is-rounded updatebtn" onclick="showPostUpdatePage()">수정</button>
+        <div class="post-boundary">
         <p><div style="font-size: xx-large; font-weight: bold;" id="title_openPost"></div></p>
         <br>
             <span style="float: left; margin-left: 8px;" id="nickname_openPost"></span>
+            <span class="button postbtn is-info is-light is-rounded" onclick="openMessageModal()">쪽지보내기</span>
             <div style="float: right">
                 <small id="datestr_openPost"></small>
             </div>

--- a/src/html/message-create-modal.html
+++ b/src/html/message-create-modal.html
@@ -9,7 +9,7 @@
         <p>
         <section class="modal-card-body">
             <div class="field" style="width:100%;">
-                <input class="input" id= "receiver_createMessage" type="email" placeholder="받는 사람 이메일주소 e.g. coco@example.com">
+                <input class="input" id= "receiver_createMessage" type="nickname" placeholder="받는 사람 닉네임을 입력해주세요.">
                 </div>
                 <div class="field" style="width:100%;">
                     <input class="input" id="title_createMessage" type="title" placeholder="제목을 입력해주세요."></div>

--- a/src/js/message.js
+++ b/src/js/message.js
@@ -34,6 +34,11 @@ window.createMessageButton = () => {
     createMessage();
 };
 
+// 글 상세페이지에서 쪽지 보내기 버튼
+window.openMessageModal = () => {
+    $('#message-create-modal').css('display', 'flex');
+};
+
 // 쪽지 상세 읽기
 window.getMessage = (messageId) => {
     getMessage(messageId);
@@ -53,7 +58,7 @@ function createMessage() {
     let content = $('#content_createMessage').val();
 
     if (receiver == '') {
-        alert('받는 사람 이메일 주소를 입력해주세요!');
+        alert('받는 사람 닉네임을 입력해주세요!');
         return;
     }
 
@@ -107,7 +112,7 @@ function getMessageList() {
 
             for (let index = 0; index < messages.length; index++) {
                 let messageId = messages[index]['id'];
-                let senderUserEmail = messages[index]['sender'];
+                let senderNickname = messages[index]['senderNickname'];
                 let title = messages[index]['title'];
                 let date = messages[index]['createDate'];
                 const day = new Date(date + '+0900').toISOString().split('T')[0];
@@ -128,7 +133,7 @@ function getMessageList() {
                                             <div class="card-content-box">
                                                 <div class="content">
                                                     <div class="tag">보낸 사람</div>
-                                                    <div class="getMessage">${senderUserEmail}</div>
+                                                    <div class="getMessage">${senderNickname}</div>
                                                 </div>
                                                 <div class="content">
                                                     <div class="tag">받은 시간</div>


### PR DESCRIPTION
- 쪽지 페이지에서 기존 발신 & 수신자 타입 Email -> Nickname 으로 보이도록 변경
- 쪽지 보낼 때도 받는사람  Email -> 닉네임 입력으로 변경
- 글 상세페이지에서 닉네임 옆에 쪽지보내기 버튼 생성 -> 쪽지 보내기 모달 띄우기