### PR TITLE
게시글 상세 조회 기능 오류 해결

### DIFF
--- a/src/js/post-detail.js
+++ b/src/js/post-detail.js
@@ -91,6 +91,10 @@ function getPost() {
             if (response.status == 403) {
                 window.openLoginModal();
             }
+            else if (response.status == 400) {
+                alert('해당 게시글이 존재하지 않습니다.');
+                window.location.href = '/home';
+            }
         }
     });
 }


### PR DESCRIPTION
#134 

- 존재하지 않는 게시글 URL로 접속하면 경고창을 띄우고 메인 화면으로 돌려보냄