### PR TITLE
쪽지 상세읽기 로직 수정

### DIFF
--- a/src/html/message-read-detail-modal.html
+++ b/src/html/message-read-detail-modal.html
@@ -3,7 +3,7 @@
         <div class="modal-card">
             <header class="modal-card-head">
                 <p class="modal-card-title" id="title-read"></p>
-                <button class="delete" onclick="closeDetailMessageModal()"></button>
+                <button class="delete" onclick="closeReadDetailMessageModal()"></button>
             </header>
             <section class="modal-card-body" id="content-read"></section>
             <footer class="modal-card-foot">

--- a/src/html/message-send-detail-modal.html
+++ b/src/html/message-send-detail-modal.html
@@ -3,7 +3,7 @@
         <div class="modal-card">
             <header class="modal-card-head">
                 <p class="modal-card-title" id="title-send"></p>
-                <button class="delete" onclick="closeDetailMessageModal()"></button>
+                <button class="delete" onclick="closeSendDetailMessageModal()"></button>
             </header>
             <section class="modal-card-body" id="content-send"></section>
             <footer class="modal-card-foot"></footer>

--- a/src/js/bookmark.js
+++ b/src/js/bookmark.js
@@ -36,19 +36,6 @@ window.getMyBookmarkList = () => {
     getMyBookmarkList();
 };
 
-// window.myBookmark = () => {
-//     getBookmarkList();
-//     let bookmarks = JSON.parse(localStorage.getItem('bookmarks'));
-//     console.log(bookmarks);
-//     for (let index = 0; index < bookmarks.length; index++) {
-//         let bookmarkId = bookmarks[index]['postId'];
-//         // let bookmarkState = bookmarks[index]['bookmarkState'];
-//         if (bookmarkState == true) {
-//             $(`#bookmarkColor-${bookmarkId}`).css('color', 'coral');
-//         }
-//     }
-// };
-
 // 북마크 색칠
 function getMyBookmarkList() {
     let token = Cookies.get('token');

--- a/src/js/message.js
+++ b/src/js/message.js
@@ -23,7 +23,6 @@ function resizeMessageContainer() {
 // 쪽지 리스트 호출
 window.initializeMessage = () => {
     getMessageList();
-    getPosts();
 };
 
 // 쪽지 리스트 불러오기
@@ -57,10 +56,15 @@ window.openSendDetailMessageModal = () => {
     $('#message-send-detail-modal').css('display', 'flex');
 };
 
-window.closeDetailMessageModal = () => {
+// 쪽지 상세보기 받은 쪽지 닫기
+window.closeReadDetailMessageModal = () => {
     $('#message-read-detail-modal').css('display', 'none');
-    $('#message-send-detail-modal').css('display', 'none');
     window.location.reload();
+};
+
+// 쪽지 상세보기 보낸 쪽지 닫기
+window.closeSendDetailMessageModal = () => {
+    $('#message-send-detail-modal').css('display', 'none');
 };
 
 // 쪽지 보내기 버튼
@@ -130,6 +134,9 @@ function createMessage() {
             console.log(response);
             if (response.responseJSON.status == 'Unknown receiver') {
                 alert('존재하지 않는 회원입니다.');
+            }
+            if (response.responseJSON.status == 'Invalid param') {
+                alert('본인에게 쪽지를 보낼 수 없습니다.');
             }
             if (response.responseJSON.status == 'Bad request') {
                 alert('쪽지 내용은 255자 이내로 작성해주세요.');
@@ -224,7 +231,6 @@ function getCreateMessageList() {
                 let messageId = messages[index]['id'];
                 let receiverNickname = messages[index]['receiver'];
                 let title = messages[index]['title'];
-                let content = messages[index]['content'];
                 let date = messages[index]['createDate'] + '+0000';
                 const day = new Date(date).toISOString().split('T')[0];
                 const time = new Date(date).toTimeString().split(' ')[0];
@@ -234,13 +240,13 @@ function getCreateMessageList() {
 
                 let messagesHTML = `<div class="card" id=${messageId} >
                                         <div class="card-header">
-                                            <p class="card-header-title" onclick="openSendDetailMessageModal(${messageId})">${title}</p>
+                                            <p class="card-header-title" onclick="getMessage(${messageId})">${title}</p>
                                             <button class="button is-light read">${read}</button>
                                             <div onclick="deleteMessage(${messageId})">
                                             <button class="delete"></button>
                                             </div>
                                         </div>
-                                        <div class="card-content" onclick="openSendDetailMessageModal(${messageId})">
+                                        <div class="card-content" onclick="getMessage(${messageId})">
                                             <div class="card-content-box">
                                                 <div class="content">
                                                     <div class="tag">받는 사람</div>
@@ -254,8 +260,6 @@ function getCreateMessageList() {
                                         </div>
                                     </div>`;
                 $('#message-list').append(messagesHTML);
-                $('#title-send').text(title);
-                $('#content-send').text(content);
             }
             resizeMessageContainer();
         },
@@ -283,7 +287,6 @@ function getMessage(messageId) {
 
         success: function (response) {
             let message = response;
-            localStorage.setItem('message', JSON.stringify(message));
 
             let member = message['member'];
             let sender = message['sender'];

--- a/src/js/message.js
+++ b/src/js/message.js
@@ -135,7 +135,7 @@ function createMessage() {
             if (response.responseJSON.status == 'Unknown receiver') {
                 alert('존재하지 않는 회원입니다.');
             }
-            if (response.responseJSON.status == 'Invalid param') {
+            if (response.responseJSON.status == 'Not allowed receiver') {
                 alert('본인에게 쪽지를 보낼 수 없습니다.');
             }
             if (response.responseJSON.status == 'Bad request') {

--- a/src/js/profile.js
+++ b/src/js/profile.js
@@ -129,7 +129,6 @@ function getProfile() {
             $('#edit-profile-modal-close-btn').on('click', closeEditProfileModal);
             $('#nickname').text(nickname);
             resizeProfileContainer();
-            getPosts();
         },
         error: function (response) {
             console.log(response);


### PR DESCRIPTION
#178 

✔︎ 문제 원인
- 기존 보낸쪽지함에서 본인이 보낸 쪽지 내용을 상세읽기할 때
receiver의 쪽지함에서 쪽지의 읽음상태가 변경(백엔드의 HTTP-`GET` 메소드에서 쪽지 상세읽기를 할 때 읽음상태는 무조건 변경됨)되지 않게하기 위해서 쪽지 상세읽기 GET메소드를 거치지 않고
보낸 쪽지 리스트를 불러오는 GET 메소드에서 Html-`id`값에 직접적으로 data(title, content) 를 보내줬던 방식을 사용했었음.
- 여기서 각 쪽지의 제목 & 내용이 `messageId` 값에 맞춰 알맞게 들어가는 것이 아닌 리스트의 첫번째 쪽지 id의 data만 중복해서 나오는 에러 확인
- 백엔드에서 `sender == receiver`일 때, 읽음상태가 변경되지 않도록 분기처리를 하면, 사용자가 본인에게 보낸 쪽지를 확인해도 읽음상태가 변경되지 않는 문제가 있음

✔︎ 문제 해결
- 백엔드에서 본인에게 쪽지를 보낼 수 없도록 수정 (보낼 경우 에러메시지 나타남)
- 기존에 보낸 쪽지리스트 GET 메소드에서 Html-`id`값에 직접적으로 data를 보내주는 방식은 더이상 사용하지 않음
- 보낸 쪽지에서는 답장보내기 버튼이 없는 모달 & 받은 쪽지를 확인할 때는 답장보내기 버튼이 있는 모달이 뜨도록 → 기존에 사용했던 분기처리만 사용해서 구분

---

- 그 외 필요없는 코드 제거